### PR TITLE
增加对TypeError的异常处理

### DIFF
--- a/pyrailgun/pattern.py
+++ b/pyrailgun/pattern.py
@@ -55,7 +55,10 @@ class Pattern:
                 if len(self.shell[key_name]) == 1 \
                 else ""
 
-            converted_strings.append(pattern.sub(replacedst, text, 1))
+            try:
+            	converted_strings.append(pattern.sub(replacedst, text, 1))
+            except:
+            	pass
 
         # support ${@} as pyrailgun's global data sets
         if matched[0].startswith('@'):


### PR DESCRIPTION
在你提供的全功能示例中会报错TypeError:NoneType has no attribute len()，导致fire()失败，增加了一下异常处理，使之能正常运行