### PR TITLE
Python3+支持及任务可重入特性

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 -------
 
-NEED Python2.7
+NEED Python2.7 or Python3+
 
 功能
 

--- a/pyrailgun/actions/fetcher.py
+++ b/pyrailgun/actions/fetcher.py
@@ -11,14 +11,14 @@ from pyrailgun.modules import cwebbrowser
 
 class FetcherAction(RailGunAction):
 
-    def action(self, task_entry, shell_groups):
+    def action(self, task_entry, shell_groups, global_data):
         if task_entry.get("webkit", False):
-            return self.__fetch_webkit(task_entry, shell_groups)
-        return self.__fetch_requests(task_entry, shell_groups)
+            return self.__fetch_webkit(task_entry, shell_groups, global_data)
+        return self.__fetch_requests(task_entry, shell_groups, global_data)
 
     # using webkit to fetch url
-    def __fetch_webkit(self, task_entry, shell_groups):
-        p = Pattern(task_entry, self.get_current_shell(task_entry, shell_groups))
+    def __fetch_webkit(self, task_entry, shell_groups, global_data):
+        p = Pattern(task_entry, self.get_current_shell(task_entry, shell_groups), global_data)
 
         task_entry['datas'] = []
 
@@ -39,9 +39,9 @@ class FetcherAction(RailGunAction):
                 browser.load(url=url, load_timeout=timeout, delay=delay)
             except cwebbrowser.Timeout:
                 self.logger.error("fetch " + url + " timeout ")
-            except Exception, exception:
+            except Exception as exception:
                 self.logger.error("fetch " + url + " error ")
-                print "Exception message:", exception
+                print("Exception message:%s" % exception)
 
             else:
                 html = browser.html()
@@ -55,8 +55,8 @@ class FetcherAction(RailGunAction):
             browser.close()
         return task_entry
 
-    def __fetch_requests(self, task_entry, shell_groups):
-        p = Pattern(task_entry, self.get_current_shell(task_entry, shell_groups))
+    def __fetch_requests(self, task_entry, shell_groups, global_data):
+        p = Pattern(task_entry, self.get_current_shell(task_entry, shell_groups), global_data)
 
         timeout = task_entry.get('timeout', 30)
         urls = p.convertPattern('url')

--- a/pyrailgun/actions/parser.py
+++ b/pyrailgun/actions/parser.py
@@ -3,15 +3,19 @@
 __author__ = 'haku-mac'
 
 import re
+import sys
 
 from bs4 import BeautifulSoup
 
 from pyrailgun.actions.action import RailGunAction
 
+if sys.version > '3':
+    unicode = str
+
 
 class ParserAction(RailGunAction):
 
-    def action(self, task_entry, shell_groups):
+    def action(self, task_entry, shell_groups, global_data):
         rule = task_entry['rule'].strip()
         self.logger.info("parsing with rule " + rule)
         strip = task_entry.get('strip')
@@ -21,7 +25,7 @@ class ParserAction(RailGunAction):
         parsed_datas = []
         for data in datas:
             self.logger.debug("parse from raw " + str(data))
-            soup = BeautifulSoup(data)
+            soup = BeautifulSoup(data, "lxml")
             parsed_data_sps = soup.select(rule)
             # set pos
             if None != pos:
@@ -32,8 +36,8 @@ class ParserAction(RailGunAction):
             for tag in parsed_data_sps:
                 tag = unicode(tag)
                 if None != attr:
-                    attr_data = BeautifulSoup(tag.encode("utf8"))
-                    tag = attr_data.contents[0].get(attr)
+                    attr_data = BeautifulSoup(tag.encode("utf8"), "lxml")
+                    tag = attr_data.contents[0].contents[0].contents[0].get(attr)
                 if strip == 'true':
                     dr = re.compile(r'<!--.*-->')
                     tag = dr.sub('', tag)

--- a/pyrailgun/modules/cwebbrowser.py
+++ b/pyrailgun/modules/cwebbrowser.py
@@ -8,6 +8,7 @@ __author__ = 'princehaku'
 
 from logger import Logger
 import time
+import sys
 
 from PyQt4.QtCore import QUrl, Qt
 from PyQt4.QtGui import QApplication
@@ -16,6 +17,9 @@ from PyQt4.QtNetwork import QNetworkRequest
 from PyQt4.QtWebKit import QWebPage, QWebView, QWebSettings
 
 app = QApplication(['dummy'])
+
+if sys.version > '3':
+    unicode = str
 
 
 class Timeout(Exception):


### PR DESCRIPTION
1、修改代码使支持Python3+，已经在Python3.6版本测试并使用；
2、增加RailGun的resetTask方法，resetTask后，任务可以换global_data继续重新进行，而不要再次setTask。适用于只需要换fetcher URL参数的爬取页；
3、修复在Python3下global_data取不到问题；
4、修复Parser在新版本BeautifulSoup获取attr语句“tag = attr_data.contents[0].get(attr)”报错问题；

ps：项目内自身包引用在Python3中好像有点问题，因为我不是pip安装，所以无法确定，所以此次pr不包括import变更。