### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ NEED Python2.7 or Python3+
   fix 一个crash问题
 
 * 0.24
-  受版权限制，替换webbroser为自己写的版本
+  受版权限制，替换web browser为自己写的版本
   去除yaml的支持

--- a/pyrailgun/actions/createShell.py
+++ b/pyrailgun/actions/createShell.py
@@ -13,7 +13,7 @@ def action(self, task_entry):
         shellid += 1
         # init shell
         self.shell_groups[shellgroup][shellid] = {}
-        # task entry splited into pieces
+        # task entry splitted into pieces
         # sub actions nums = now sub nums * shell num
         subact = {
             "action": "faketask",

--- a/pyrailgun/railgun.py
+++ b/pyrailgun/railgun.py
@@ -143,7 +143,7 @@ class RailGun:
             shellid += 1
             # init shell
             shell_groups[shellgroup][shellid] = {}
-            # task entry splited into pieces
+            # task entry splitted into pieces
             # sub actions nums = now sub nums * shell num
             subact = {
                 "action": "faketask",


### PR DESCRIPTION
There are small typos in:
- README.md
- pyrailgun/actions/createShell.py
- pyrailgun/railgun.py

Fixes:
- Should read `splitted` rather than `splited`.
- Should read `web browser` rather than `webbroser`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md